### PR TITLE
Fix unable to lock after invalid MQTT message

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -56,6 +56,12 @@ class MessageWaiter():
             log_mqtt.warning('MesssageWaiter: Exception match check: {}'.format(e))
 
 def mqtt_message_received(client, u, message):
+    try:
+        mqtt_handle_message(client, u, message)
+    except Exception as e:
+        log_mqtt.exception('Failed to handle message %: %s '.format(message.topic, message.payload))
+
+def mqtt_handle_message(client, u, message):
     log_mqtt.debug('received {}: {}'.format(message.topic, message.payload))
 
     if message.topic == 'fbp':
@@ -136,6 +142,8 @@ def create_mqtt_client(broker_url):
                 client.loop(timeout=0.2)
                 # Yield to other greenlets so they don't starve
                 gevent.sleep(0.2)
+            except Exception as e:
+                log_mqtt.exception('Loop exception:')
             finally:
                 pass
     gevent.Greenlet.spawn(_mqtt_loop)

--- a/gateway/test_gateway.py
+++ b/gateway/test_gateway.py
@@ -98,6 +98,14 @@ def devices():
     testdevices.run()
     gevent.sleep(1) # let the devices spin up
 
+@pytest.fixture(scope="module")
+def mqtt_test_client():
+    broker_url = os.environ.get('MSGFLO_BROKER', 'mqtt://localhost')
+    mqtt_client, host, port = gateway.create_mqtt_client(broker_url)
+    timeout = 5
+    mqtt_client.connect(host, port, timeout)
+    return mqtt_client
+
 
 # POST /door/id/unlock
 def test_unlock_successful(devices):
@@ -181,4 +189,26 @@ def test_status_seen_but_too_long_ago(devices):
         assert r.status_code == 503, body
         details = json.loads(body)
         assert details['doors']['virtual-1']['status'] == 503
+
+def test_invalid_fbp_message(devices, mqtt_test_client):
+    '''should not influence future messages'''
+
+    with app.test_client() as c:
+        status_url = "status?ignore=sorenga-1&ignore=notresponding-1"
+        r = c.get(status_url)
+        body = r.data.decode('utf8')
+        assert r.content_type == 'application/json'
+        assert r.status_code == 200, body
+
+        # Send invalid message
+        mqtt_test_client.publish('fbp', '{}')
+        gevent.sleep(0.5)
+
+        # check still works
+        r = c.post("doors/virtual-1/unlock?duration=1", **authed())
+        body = r.data.decode('utf8')
+        assert r.status_code == 200
+        # ensure is locked again at end of test
+        gevent.sleep(1.1)
+
 

--- a/gateway/test_gateway.py
+++ b/gateway/test_gateway.py
@@ -8,6 +8,8 @@ import gevent
 import json
 import base64
 
+import os
+
 app = gateway.app
 gateway.api_users['TEST_USER'] = 'XXX_TEST_PASSWORD'
 
@@ -91,7 +93,8 @@ def test_wrong_ip_403(devices):
 
 @pytest.fixture(scope="module")
 def devices():
-    gateway.mqtt_client = gateway.create_client()
+    gateway.mqtt_client = gateway.setup_mqtt_client()
+    gevent.sleep(1) # ensure we are connected/subcribed before discovery
     testdevices.run()
     gevent.sleep(1) # let the devices spin up
 


### PR DESCRIPTION
The receive callback could throw uncaught exception, which would exit the polling loop for MQTT messages and prevent further messages being processed.