### PR TITLE
/unlock: Set default value for duration [APIBREAK]

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -17,7 +17,7 @@ HTTP Basic Auth with server-side TLS encryption.
 Response status
 
     200: Door is now unlocked.
-        If $duration specified, will automatically lock after  seconds
+        Will automatically lock again after $duration seconds
 
     503: Unlock failed, device or message broker responded with error
     504: Unlock failed, device communication timed out
@@ -25,17 +25,6 @@ Response status
     404: Unknown door ID
     422: Invalid or out-of-range value for `duration` parameter
     403: Wrong or missing auth
-```
-
-## Lock door
-
-```
-    POST /doors/$door_id/lock
-
-Response status
-
-    200: Door is now locked
-
 ```
 
 

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -273,10 +273,8 @@ def door_unlock(doorid):
         return ("Invalid timeout specified", 422)
 
     try:
-        duration = flask.request.args.get('duration', None)
-        if duration:
-          duration = int(duration)
-          assert_not_outside(duration, 1, 10*60)
+        duration = int(flask.request.args.get('duration', '2'))
+        assert_not_outside(duration, 1, 10*60)
     except ValueError as e:
         return ("Invalid duration: {}".format(flask.escape(str(e))), 422)
 
@@ -290,7 +288,7 @@ def door_unlock(doorid):
     mqtt_message_waiters.append(wait_response)
 
     # Send message to request unlocking
-    payload = 'true' if duration is None else str(duration)
+    payload = str(duration)
     mqtt_send(mqtt_prefix + "/unlock", payload)
 
     # Wait for response


### PR DESCRIPTION
Means that it is no longer possible to open door forever,
which was an unused feature