### PR TITLE
Hash apikeys

### DIFF
--- a/gateway/apikey.py
+++ b/gateway/apikey.py
@@ -1,0 +1,22 @@
+
+import werkzeug.security as wsecurity
+import random
+import string
+import sys
+
+def randomstring(length):
+   letters = (random.choice(string.ascii_lowercase) for i in range(length))
+   return ''.join(letters)
+
+def main():
+    password = randomstring(16)
+
+    if len(sys.argv) > 1:
+        password = sys.argv[1]
+
+    hashed = wsecurity.generate_password_hash(password)
+    print(password)
+    print(hashed)
+
+if __name__ == '__main__':
+    main()

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -11,6 +11,7 @@ gevent.monkey.patch_all() # make sure all syncronous calls in stdlib yields to g
 import gevent.wsgi
 import flask
 import paho.mqtt.client as mqtt
+import werkzeug.security as wsecurity
 
 from urllib.parse import urlparse
 import os
@@ -171,10 +172,10 @@ def find_door_id(role):
 
 def require_basic_auth(f):
     def check_auth(username, password):
-        found_password = api_users.get(username, None)
-        if found_password is None:
+        found_hash = api_users.get(username, None)
+        if found_hash is None:
             return False
-        return found_password == password
+        return wsecurity.check_password_hash(found_hash, password)
 
     @functools.wraps(f)
     def decorated(*args, **kwargs):

--- a/gateway/test_gateway.py
+++ b/gateway/test_gateway.py
@@ -7,11 +7,12 @@ import pytest
 import gevent
 import json
 import base64
+import werkzeug.security as wsecurity
 
 import os
 
 app = gateway.app
-gateway.api_users['TEST_USER'] = 'XXX_TEST_PASSWORD'
+gateway.api_users['TEST_USER'] = wsecurity.generate_password_hash('XXX_TEST_PASSWORD')
 
 def basic_auth(u, p):
     s = "{}:{}".format(u, p)


### PR DESCRIPTION
The values in envvar DLOCK_API_CREDENTIALS must be hashed.
Existing plaintext passwords can be converted using

    python3 gateway/apikey.py plaintext

To generate a new password run

    python3 gateway/apikey.py