### PR TITLE
Fix gateway reconnect to MQTT broker

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -8,7 +8,7 @@ and presents a syncronous API.
 import gevent.monkey
 gevent.monkey.patch_all() # make sure all syncronous calls in stdlib yields to gevent
 
-import gevent.wsgi
+import gevent.pywsgi
 import flask
 import paho.mqtt.client as mqtt
 import werkzeug.security as wsecurity
@@ -379,7 +379,7 @@ def main():
 
     port = os.environ.get('PORT', 5000)
     ip = os.environ.get('INTERFACE', '127.0.0.1')
-    server = gevent.wsgi.WSGIServer((ip, port), app)
+    server = gevent.pywsgi.WSGIServer((ip, port), app)
     log.info('Gateway running on {}:{}'.format(ip, port))
     server.serve_forever()
 


### PR DESCRIPTION
Every few weeks or so the gateway would give error status and fail to communicate with the doorlocks, not sending any MQTT messages out. The same symptoms also happened on a Mosquitto restart, indicating that reconnection was not working as intended. And yes, apparently paho.mqtt.client.Client.loop() does not implement this logic, so have to use loop_start()

Also now log in 'disconnect', so such issues can be debugged easier