### PR TITLE
[WIP] gateway: Use structlog for structured logging

### DIFF
--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,3 +1,4 @@
 flask>=0.12
 gevent>=1.2
 paho-mqtt>=1.3
+structlog>=19.2.0


### PR DESCRIPTION
Makes it possible to filter logs for a particular door or request,
and to monitor processing times for HTTP requests and MQTT messages

![unlockoslo-structlog1](https://user-images.githubusercontent.com/45185/72226419-42795780-3591-11ea-8ca1-2d42f032307b.png)

For now the log events are quite centered around the HTTP and MQTT loops. 

Would be possible to add more "application logic specific" events, if desired.
Feedback on what more information is desirable to log is welcomed.

Right now `key=value` rendering is for the output. It is possible to change this to JSON, at least for the file log.

